### PR TITLE
Add quotes to field.name to support field names with spaces

### DIFF
--- a/jquery_pivot.js
+++ b/jquery_pivot.js
@@ -161,7 +161,7 @@ var methods = {
     if (fieldName === '') return;
 
     // Check to see if this field has already been built
-    var filterExists = $('#filter-list select[data-field=' + field.name + ']');
+    var filterExists = $('#filter-list select[data-field="' + field.name + '"]');
     if (filterExists.length) return;
 
     if (field.filterType === 'regexp')


### PR DESCRIPTION
The quotes around field.name is present everywhere except line #164. Added. This is to enable support for field names with spaces. I have not updated the spec, though.
